### PR TITLE
Created Metadata Widget

### DIFF
--- a/src/github_feed/components/metadata_panel.py
+++ b/src/github_feed/components/metadata_panel.py
@@ -1,4 +1,5 @@
-import os
+from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 from rich.align import Align
@@ -14,30 +15,37 @@ class PanelParts(BaseModel):
     body: RenderableType
 
 
-def _build_starred_repos_line() -> str:
-    line = "🌟 [bold cyan]Starred Repository Count[/]:"
-
+def _build_starred_repos_line(repo_count: int) -> str:
+    line = f"🌟 [bold cyan]Starred Repository Count[/]: [bold green]{repo_count!s}[/]"
     return line
 
 
-def _build_last_checked_line() -> str:
-    line = "⌚ [bold cyan]Last Checked[/]:"
+def _build_last_checked_line(timestamp: datetime | None) -> str:
+    if timestamp is None:
+        line = "⌚ [bold cyan]Last Checked[/]: [bold red]Never[/]"
+    else:
+        line = f"⌚ [bold cyan]Last Checked[/]: [bold green]{timestamp.isoformat()}[/]"
     return line
 
 
-def _build_body() -> RenderableType:
-    line_1 = _build_starred_repos_line()
-    line_2 = _build_last_checked_line()
+def _build_body(starred_count: int, last_checked: datetime | None) -> RenderableType:
+    line_1 = _build_starred_repos_line(starred_count)
+    line_2 = _build_last_checked_line(last_checked)
     body_lines = "\n".join([line_1, "", line_2])
     return Align.center(body_lines)
 
 
-def build_panel_parts() -> PanelParts:
-    return PanelParts(title="Metadata", body=_build_body())
+def build_panel_parts(starred_count: int, last_checked: datetime | None) -> PanelParts:
+    return PanelParts(title="Metadata", body=_build_body(starred_count, last_checked))
 
 
 class MetadataPanel(Static):
+    def __init__(self, starred_repo_count: int, last_checked: datetime | None = None, **kwargs: Any) -> None:
+        self.starred_repo_count = starred_repo_count
+        self.last_checked = last_checked
+        super().__init__(**kwargs)
+
     def on_mount(self) -> None:
-        panel_parts = build_panel_parts()
+        panel_parts = build_panel_parts(self.starred_repo_count, self.last_checked)
         panel = Panel(panel_parts.body, title=panel_parts.title, expand=False, padding=(1, 1))
         self.update(panel)

--- a/src/github_feed/components/metadata_panel.py
+++ b/src/github_feed/components/metadata_panel.py
@@ -1,0 +1,43 @@
+import os
+
+from pydantic import BaseModel, ConfigDict
+from rich.align import Align
+from rich.console import RenderableType
+from rich.panel import Panel
+from textual.widgets import Static
+
+
+class PanelParts(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    title: str
+    body: RenderableType
+
+
+def _build_starred_repos_line() -> str:
+    line = "🌟 [bold cyan]Starred Repository Count[/]:"
+
+    return line
+
+
+def _build_last_checked_line() -> str:
+    line = "⌚ [bold cyan]Last Checked[/]:"
+    return line
+
+
+def _build_body() -> RenderableType:
+    line_1 = _build_starred_repos_line()
+    line_2 = _build_last_checked_line()
+    body_lines = "\n".join([line_1, "", line_2])
+    return Align.center(body_lines)
+
+
+def build_panel_parts() -> PanelParts:
+    return PanelParts(title="Metadata", body=_build_body())
+
+
+class MetadataPanel(Static):
+    def on_mount(self) -> None:
+        panel_parts = build_panel_parts()
+        panel = Panel(panel_parts.body, title=panel_parts.title, expand=False, padding=(1, 1))
+        self.update(panel)

--- a/src/github_feed/css/tui.tcss
+++ b/src/github_feed/css/tui.tcss
@@ -13,7 +13,7 @@ Screen {
     width: 50%;
 }
 
-#starredReposCount {
+#metadataPanel {
     height: 1fr;
     width: 50%;
 }

--- a/src/github_feed/tui.py
+++ b/src/github_feed/tui.py
@@ -3,6 +3,7 @@ from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, Header, Label
 
 from github_feed.components.env_var_panel import EnvVarPanel
+from github_feed.components.metadata_panel import MetadataPanel
 
 
 class GitHubFeed(App[str]):
@@ -13,7 +14,8 @@ class GitHubFeed(App[str]):
         yield Vertical(
             Horizontal(
                 EnvVarPanel(shrink=True, id="envVarPanel"),
-                Label("Current number of starred repos", id="starredReposCount"),
+                MetadataPanel(id="metadataPanel"),
+                # Label("Current number of starred repos", id="starredReposCount"),
                 classes="row",
             ),
             Horizontal(

--- a/src/github_feed/tui.py
+++ b/src/github_feed/tui.py
@@ -1,6 +1,6 @@
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical
-from textual.widgets import Button, Header, Label
+from textual.widgets import Button, Header
 
 from github_feed.components.env_var_panel import EnvVarPanel
 from github_feed.components.metadata_panel import MetadataPanel
@@ -14,8 +14,7 @@ class GitHubFeed(App[str]):
         yield Vertical(
             Horizontal(
                 EnvVarPanel(shrink=True, id="envVarPanel"),
-                MetadataPanel(id="metadataPanel"),
-                # Label("Current number of starred repos", id="starredReposCount"),
+                MetadataPanel(323, id="metadataPanel"),
                 classes="row",
             ),
             Horizontal(


### PR DESCRIPTION
This pull request introduces a new `MetadataPanel` component to the GitHub feed application and replaces the existing starred repositories count label with this new component. The changes include the creation of a new class, updates to the layout, and modifications to the CSS.

Key changes include:

### New Component Addition:
* Added `MetadataPanel` class in `src/github_feed/components/metadata_panel.py` to display metadata including the starred repository count and last checked timestamp.

### Layout Update:
* Replaced the `Label` for the starred repositories count with the new `MetadataPanel` in the `compose` method of `src/github_feed/tui.py`.

### CSS Update:
* Updated the CSS to reflect the new `MetadataPanel` ID by replacing `#starredReposCount` with `#metadataPanel` in `src/github_feed/css/tui.tcss`.