### PR TITLE
Basic Styling for Home Screen

### DIFF
--- a/src/github_feed/css/tui.tcss
+++ b/src/github_feed/css/tui.tcss
@@ -1,24 +1,23 @@
-Static {
-    # content-align: center middle;
-}
-
 Screen {
     layout: vertical;
     align: center middle;
 }
 
-#envVarPanel {
-    height: 1fr;
+EnvVarPanel {
+    height: auto;
     width: 50%;
+    content-align: right middle;
+    padding-right: 5;
 }
 
 #metadataPanel {
-    height: 1fr;
+    height: auto;
     width: 50%;
+    content-align: left middle;
+    padding-left: 5;
 }
 
 .row {
-    content-align: center middle;
     height: 1fr;
     align: center middle;
 }

--- a/src/github_feed/tui.py
+++ b/src/github_feed/tui.py
@@ -4,7 +4,7 @@ from typing import Any, ClassVar
 from textual import on, work
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical
-from textual.events import ScreenResume
+from textual.events import Ready, ScreenResume
 from textual.screen import Screen
 from textual.widgets import Button, DataTable, Header, Label
 from textual.worker import Worker, get_current_worker
@@ -19,17 +19,21 @@ from github_feed.models import Repository
 class Home(Screen):  # type: ignore[type-arg]
     BINDINGS: ClassVar = [("escape", "app.pop_screen", "Pop screen")]
 
+    def __init__(self, **kwargs: Any) -> None:
+        self.engine = Engine()
+        super().__init__(**kwargs)
+
     def compose(self) -> ComposeResult:
         yield Header()
         yield Vertical(
             Horizontal(
                 EnvVarPanel(shrink=True, id="envVarPanel"),
-                MetadataPanel(323, id="metadataPanel"),
+                MetadataPanel(self.engine, 323, id="metadataPanel"),
                 classes="row",
             ),
             Horizontal(
                 Button("Check for New Releases", id="checkReleases", variant="primary"),
-                Button("Refresh List of Starred Repos", id="checkStarred", variant="error"),
+                Button("Refresh List of Starred Repos", id="checkStarred", variant="default"),
                 classes="row",
             ),
         )
@@ -133,7 +137,12 @@ class GitHubFeed(App[str]):
         ("s", "push_screen('starred_repos')", "STARRED REPOS"),
     ]
 
+    def __init__(self, **kwargs: Any) -> None:
+        self.engine = Engine()
+        super().__init__(**kwargs)
+
     async def on_mount(self) -> None:
+        self.theme = "tokyo-night"
         self.install_screen(Home(), name="home")
         self.install_screen(Releases(), name="releases")
         self.install_screen(StarredRepos(), name="starred_repos")


### PR DESCRIPTION
### Changes

- Set default theme as tokyo-night
- Updated metadata panel to use actual number of starred repos according to db

### Extended Summary

This pull request includes several changes to enhance the functionality of the `MetadataPanel` and improve the overall user interface of the GitHub feed application. The most important changes include the addition of an `Engine` instance to the `MetadataPanel` and the `Home` screen, new methods for loading metadata, and updates to the CSS for better layout and alignment.

Enhancements to `MetadataPanel`:

* [`src/github_feed/components/metadata_panel.py`](diffhunk://#diff-3fa2ef09a19981c31308f934bde1d0f40226ad18b9bafea535aa2981126fb437L43-R51): Added an `Engine` instance to the `MetadataPanel` constructor and implemented new methods `handle_screen_resume` and `load_metadata` to load metadata asynchronously when the screen is shown. [[1]](diffhunk://#diff-3fa2ef09a19981c31308f934bde1d0f40226ad18b9bafea535aa2981126fb437L43-R51) [[2]](diffhunk://#diff-3fa2ef09a19981c31308f934bde1d0f40226ad18b9bafea535aa2981126fb437R60-R73)

UI improvements:

* [`src/github_feed/css/tui.tcss`](diffhunk://#diff-1f3e88813a17dcc13105a538a3f71f2e437c002b9079504cb291cc7c7219b7b7L1-L21): Updated the CSS to adjust the height, width, alignment, and padding of `EnvVarPanel` and `metadataPanel` for better layout and visual alignment.

Initialization of `Engine` in `Home` screen and main application:

* [`src/github_feed/tui.py`](diffhunk://#diff-f5d80186a71b9481b52bdfc2269d8a87f347ca6ff942c95b0ad3976a791ca281R22-R36): Added an `Engine` instance to the `Home` screen and the main `GitHubFeed` application class, and passed it to the `MetadataPanel`. Also, updated the theme to "tokyo-night". [[1]](diffhunk://#diff-f5d80186a71b9481b52bdfc2269d8a87f347ca6ff942c95b0ad3976a791ca281R22-R36) [[2]](diffhunk://#diff-f5d80186a71b9481b52bdfc2269d8a87f347ca6ff942c95b0ad3976a791ca281R140-R145)