### PR TITLE
fix: sort releases in async implementation before returning

### DIFF
--- a/src/github_feed/engine.py
+++ b/src/github_feed/engine.py
@@ -166,4 +166,5 @@ class Engine:
                 except IntegrityError:
                     # We already have this release in the table
                     logger.info("Release %s already exists in the db", result.name)
+        releases.sort(key=lambda x: x.created_at, reverse=True)
         return releases


### PR DESCRIPTION
This pull request includes a minor improvement to the `retrieve_fresh_releases_async` method in `src/github_feed/engine.py`. The change ensures that the list of releases is sorted by their `created_at` timestamp in descending order before being returned.

* [`src/github_feed/engine.py`](diffhunk://#diff-1639695a1eedbe30f022cbecd649be27bf0e5503a9466583b40bbf9065dd7e36R169): Added a sort operation to the `releases` list to order entries by `created_at` in reverse chronological order.