### PR TITLE
Support Multiple Fresh Releases in Time Window

### DIFF
--- a/src/github_feed/engine.py
+++ b/src/github_feed/engine.py
@@ -171,7 +171,7 @@ class Engine:
                     try:
                         self.db.add_release(SqlRelease(**result.model_dump()))
                     except IntegrityError:
-                        logger.info("Release %s already exists in the db", result.name)
+                        logger.debug("Release %s already exists in the db", result.name)
         releases.sort(key=lambda x: x.created_at, reverse=True)
         logger.info("Retrieved fresh %d releases", len(releases))
         return releases


### PR DESCRIPTION
Closes #10 

This pull request refactors the release retrieval logic to improve error handling, add rate limit logging, and enhance asynchronous operations. The most notable changes include replacing single-release fetching with batch release fetching, introducing a rate limit logging utility, and simplifying the release retrieval flow.

### Enhancements to release retrieval logic:
* Refactored `retrieve_fresh_releases_async` to fetch all releases for updated repositories in batches, improving efficiency and error handling. Each repository's releases are now retrieved asynchronously, and warnings are logged for individual failures.
* Replaced the `_fetch_latest_release` method with `_fetch_releases_for_repo`, which retrieves all releases for a repository instead of just the latest one. This method includes improved exception handling and validates the response data.

### Rate limit logging:
* Added `_log_rate_limit` utility to log API rate limit details (e.g., limit, remaining, used, reset time) for better monitoring. This is invoked during API calls, such as fetching starred repositories and releases. [[1]](diffhunk://#diff-6f7fcf94c2bdb87537702926e8285def084b43c89ac853de64138c296a5f5e0dR71) [[2]](diffhunk://#diff-6f7fcf94c2bdb87537702926e8285def084b43c89ac853de64138c296a5f5e0dL117-R158)

### Code cleanup and improvements:
* Removed the unused `_fetch_latest_release` method and its associated logic, simplifying the codebase.
* Updated imports in `github_client.py` to include `datetime` and `UTC` for rate limit logging functionality.